### PR TITLE
Stan automation fix

### DIFF
--- a/beautify.bat
+++ b/beautify.bat
@@ -1,1 +1,1 @@
-php ./phpcbf.phar --standard=.phpcs.xml
+php ./phpcbf.phar.1 --standard=.phpcs.xml

--- a/sniff.bat
+++ b/sniff.bat
@@ -1,1 +1,1 @@
-php ./phpcs.phar --standard=.phpcs.xml
+php ./phpcs.phar.1 --standard=.phpcs.xml


### PR DESCRIPTION
Fix issue with phpcs.phar and phpcbf.phar archives by changing the call in batch file

archives are now named
phpcs.phar.1
phpcbf.phar.1
and are now correctly referenced in both batch files