### PR TITLE
Fix error messages on find page

### DIFF
--- a/src/controller/OfferController.php
+++ b/src/controller/OfferController.php
@@ -309,13 +309,13 @@ class OfferController extends BaseController
     {
         //prepare search parameter
         /** @var string $destination */
-        $destination = $param['destination'];
+        $destination = $param['destination'] ?? '';
         /** @var string $dateStart */
-        $dateStart = $param['dateStart'];
+        $dateStart = $param['dateStart'] ?? '';
         /** @var string $dateEnd */
-        $dateEnd = $param['dateEnd'];
+        $dateEnd = $param['dateEnd'] ?? '';
         /** @var string $persons */
-        $persons = (int)$param['persons'];
+        $persons = (int)($param['persons'] ?? 0);
         $query = "
 SELECT *
 FROM houses h


### PR DESCRIPTION
Providing default values prevents null value given error.