### PR TITLE
Use prefill instead of pold function and prefill offer creation after redirect

### DIFF
--- a/public/scripts/offer-create.js
+++ b/public/scripts/offer-create.js
@@ -284,3 +284,17 @@ optionalImageDropArea.addEventListener("drop", function (e) {
 
 // Handle the change event of the optional image input field
 optionalImageSelectElement.addEventListener("change", (e) => addOptionalImage(e.target.files), false);
+
+
+/**
+ * Add all given tags to the tags card
+ *
+ * @param tags
+ */
+function prefillTags(tags) {
+    const tagsArray = tags.split(",");
+    const count = tagsArray.length;
+    for (var i=0; i<count; i++) {
+        addTag(String(tagsArray[i]));
+    }
+}

--- a/src/views/createNewOffer.view.php
+++ b/src/views/createNewOffer.view.php
@@ -5,17 +5,6 @@ $title = "Haus anlegen";
 $page = 'createhouse';
 $_SESSION['previous'] = $_SERVER['REQUEST_URI'];
 $features = $param['features'] ?? null;
-/**
- * @param string $string
- * @return void
- */
-function pold($string): void
-{
-    $old = $_SESSION['old_POST'] ?? null;
-    if (isset($old)) {
-        print $old[$string] ?? '';
-    }
-}
 
 include_once($header);
 ?>
@@ -36,52 +25,52 @@ echo($message ?? "<h1>$message</h1>"); // @phpstan-ignore-line
         <div id="detail-grid">
             <div id="name-area">
                 <label class="label" for="name">Name der Anlage*</label>
-                <input class="input-field" type="text" name="base-data[name]" id="name" value="<?php pold('name') ?>" required
+                <input class="input-field" type="text" name="base-data[name]" id="name" value="<?php prefill('name') ?>" required
                        autofocus>
             </div>
             <div id="city-area">
                 <label class="label" for="city">Ort*</label>
-                <input class="input-field" type="text" name="base-data[city]" id="city" value="<?php pold('city') ?>" required>
+                <input class="input-field" type="text" name="base-data[city]" id="city" value="<?php prefill('city') ?>" required>
             </div>
             <div id="postal-code-area">
                 <label class="label" for="postal-code">Postleitzahl*</label>
                 <input class="input-field" type="number" name="base-data[postal_code]" id="postal-code" maxlength="5"
-                       value="<?php pold('postal_code') ?>" required>
+                       value="<?php prefill('postal_code') ?>" required>
             </div>
             <div id="street-area">
                 <label class="label" for="street">Straße*</label>
-                <input class="input-field" type="text" name="base-data[street]" id="street" value="<?php pold('street') ?>"
+                <input class="input-field" type="text" name="base-data[street]" id="street" value="<?php prefill('street') ?>"
                        required>
             </div>
             <div id="house-number-area">
                 <label class="label" for="house-number">Hausnummer*</label>
                 <input class="input-field" type="number" name="base-data[house_number]" id="house-number" min="1"
-                       value="<?php pold('house_number') ?>" required>
+                       value="<?php prefill('house_number') ?>" required>
             </div>
             <div id="square-meter-area">
                 <label class="label" for="square-meter">Quadratmeter*</label>
                 <input class="input-field" type="number" name="base-data[square_meter]" id="square-meter" min="1"
-                       value="<?php pold('square_meter') ?>" required>
+                       value="<?php prefill('square_meter') ?>" required>
             </div>
             <div id="room-count-area">
                 <label class="label" for="room-count">Anzahl Räume*</label>
                 <input class="input-field" type="number" name="base-data[room_count]" id="room-count" min="1"
-                       value="<?php pold('room_count') ?>" required>
+                       value="<?php prefill('room_count') ?>" required>
             </div>
             <div id="max-person-area">
                 <label class="label" for="max-person">Anzahl mögliche Personen*</label>
                 <input class="input-field" type="number" name="base-data[max_person]" id="max-person" min="1"
-                       value="<?php pold('max_person') ?>" required>
+                       value="<?php prefill('max_person') ?>" required>
             </div>
             <div id="price-area">
                 <label class="label" for="price">Preis pro Nacht*</label>
                 <input class="input-field" type="number" name="base-data[price]" id="price" min="1"
-                       value="<?php pold('price') ?>" required>
+                       value="<?php prefill('price') ?>" required>
             </div>
             <div id="description-area">
                 <label class="label" for="description">Beschreibung*</label>
                 <textarea class="input-field" name="base-data[description]" id="description" cols="30" required
-                          rows="10"><?php pold('description') ?></textarea>
+                          rows="10"><?php prefill('description') ?></textarea>
             </div>
         </div>
 

--- a/src/views/createNewOffer.view.php
+++ b/src/views/createNewOffer.view.php
@@ -5,13 +5,18 @@ $title = "Haus anlegen";
 $page = 'createhouse';
 $_SESSION['previous'] = $_SERVER['REQUEST_URI'];
 $features = $param['features'] ?? null;
+$oldTagsSelected = $_SESSION['old_POST']['tags'];
 
 include_once($header);
 ?>
 <link rel="stylesheet" href="/styles/offer-create.css"/>
-<?php
-echo($message ?? "<h1>$message</h1>"); // @phpstan-ignore-line
-?>
+
+<?php if (isset($message)) { ?>
+    <script>
+        showNotification("<?php echo $message; ?>", 20000);
+    </script>
+<?php } ?>
+
 <form action="/offer/create" method="post" enctype="multipart/form-data" id="create-offer-form">
 
     <div id="new-offer-area">
@@ -25,52 +30,52 @@ echo($message ?? "<h1>$message</h1>"); // @phpstan-ignore-line
         <div id="detail-grid">
             <div id="name-area">
                 <label class="label" for="name">Name der Anlage*</label>
-                <input class="input-field" type="text" name="base-data[name]" id="name" value="<?php prefill('name') ?>" required
+                <input class="input-field" type="text" name="base-data[name]" id="name" value="<?php echo $_SESSION['old_POST']['base-data']['name'] ?? ""; ?>" required
                        autofocus>
             </div>
             <div id="city-area">
                 <label class="label" for="city">Ort*</label>
-                <input class="input-field" type="text" name="base-data[city]" id="city" value="<?php prefill('city') ?>" required>
+                <input class="input-field" type="text" name="base-data[city]" id="city" value="<?php echo $_SESSION['old_POST']['base-data']['city'] ?? ""; ?>" required>
             </div>
             <div id="postal-code-area">
                 <label class="label" for="postal-code">Postleitzahl*</label>
                 <input class="input-field" type="number" name="base-data[postal_code]" id="postal-code" maxlength="5"
-                       value="<?php prefill('postal_code') ?>" required>
+                       value="<?php echo $_SESSION['old_POST']['base-data']['postal_code'] ?? ""; ?>" required>
             </div>
             <div id="street-area">
                 <label class="label" for="street">Straße*</label>
-                <input class="input-field" type="text" name="base-data[street]" id="street" value="<?php prefill('street') ?>"
+                <input class="input-field" type="text" name="base-data[street]" id="street" value="<?php echo $_SESSION['old_POST']['base-data']['street'] ?? ""; ?>"
                        required>
             </div>
             <div id="house-number-area">
                 <label class="label" for="house-number">Hausnummer*</label>
                 <input class="input-field" type="number" name="base-data[house_number]" id="house-number" min="1"
-                       value="<?php prefill('house_number') ?>" required>
+                       value="<?php echo $_SESSION['old_POST']['base-data']['house_number'] ?? ""; ?>" required>
             </div>
             <div id="square-meter-area">
                 <label class="label" for="square-meter">Quadratmeter*</label>
                 <input class="input-field" type="number" name="base-data[square_meter]" id="square-meter" min="1"
-                       value="<?php prefill('square_meter') ?>" required>
+                       value="<?php echo $_SESSION['old_POST']['base-data']['square_meter'] ?? ""; ?>" required>
             </div>
             <div id="room-count-area">
                 <label class="label" for="room-count">Anzahl Räume*</label>
                 <input class="input-field" type="number" name="base-data[room_count]" id="room-count" min="1"
-                       value="<?php prefill('room_count') ?>" required>
+                       value="<?php echo $_SESSION['old_POST']['base-data']['room_count'] ?? ""; ?>" required>
             </div>
             <div id="max-person-area">
                 <label class="label" for="max-person">Anzahl mögliche Personen*</label>
                 <input class="input-field" type="number" name="base-data[max_person]" id="max-person" min="1"
-                       value="<?php prefill('max_person') ?>" required>
+                       value="<?php echo $_SESSION['old_POST']['base-data']['max_person'] ?? ""; ?>" required>
             </div>
             <div id="price-area">
                 <label class="label" for="price">Preis pro Nacht*</label>
                 <input class="input-field" type="number" name="base-data[price]" id="price" min="1"
-                       value="<?php prefill('price') ?>" required>
+                       value="<?php echo $_SESSION['old_POST']['base-data']['price'] ?? ""; ?>" required>
             </div>
             <div id="description-area">
                 <label class="label" for="description">Beschreibung*</label>
                 <textarea class="input-field" name="base-data[description]" id="description" cols="30" required
-                          rows="10"><?php prefill('description') ?></textarea>
+                          rows="10"><?php echo $_SESSION['old_POST']['base-data']['description'] ?? ""; ?></textarea>
             </div>
         </div>
 
@@ -122,7 +127,10 @@ echo($message ?? "<h1>$message</h1>"); // @phpstan-ignore-line
                     </div>
                     <?php foreach ($category as $feature) { ?>
                         <label class="feature-select">
-                            <input type="checkbox" name="<?php echo 'features['.$categoryName.'][]" value="'.$feature->getName(); ?>">
+                            <input type="checkbox" name="<?php echo 'features['.$categoryName.'][]" value="'.$feature->getName(); ?>"
+                                <?php if (in_array($feature->getName(), ($_SESSION['old_POST']['features'][$categoryName] ?? []))) {
+                                    echo ' checked';
+                                }?>>
                             <?php echo $feature->getName(); ?>
                         </label>
                     <?php } ?>
@@ -155,3 +163,7 @@ include_once($footer)
 ?>
 
 <script src="/scripts/offer-create.js"></script>
+
+<script>
+    prefillTags("<?php echo $oldTagsSelected ?>");
+</script>

--- a/src/views/search.view.php
+++ b/src/views/search.view.php
@@ -4,18 +4,6 @@ $title = "dashboard";
 $site = "dashboard";
 $houses = $param['houses'] ?? [];
 
-/**
- * @param string $string
- * @return void
- */
-function pold($string): void
-{
-    $old = $_SESSION['old_POST'] ?? null;
-    if (isset($old)) {
-        print $old[$string] ?? '';
-    }
-}
-
 $features = $param['features'] ?? [];
 $featuresSel = $param['featuresSelected'] ?? [];
 $tagsSel = $param['tagsSelected'] ?? '';
@@ -28,20 +16,20 @@ include_once($header);
         <div id="search-grid">
             <div id="destination" class="search-input" style="display: inline-block;text-align: left">
                 <label id="destination-label" style="display: block" for="destination-input-field">Reiseziel</label>
-                <input id="destination-input-field" placeholder="Rügen" class="input-field" name="destination" type="text" value="<?php pold('destination') ?>">
+                <input id="destination-input-field" placeholder="Rügen" class="input-field" name="destination" type="text" value="<?php prefill('destination') ?>">
             </div>
             <div id="from-date" class="search-input" style="display: inline-block">
                 <label id="from-date-label" for="from-date-input-field"
                        style="display: block;text-align: left">Anreise</label>
-                <input id="from-date-input-field" class="input-field" name="dateStart" type="date" value="<?php pold('dateStart') ?>">
+                <input id="from-date-input-field" class="input-field" name="dateStart" type="date" value="<?php prefill('dateStart') ?>">
             </div>
             <div id="to-date" class="search-input" style="display: inline-block">
                 <label id="to-date-label" for="to-date-label-input-field" style="display: block;text-align: left">Abreise</label>
-                <input id="to-date-label-input-field" class="input-field" name="dateEnd" type="date" value="<?php pold('dateEnd') ?>">
+                <input id="to-date-label-input-field" class="input-field" name="dateEnd" type="date" value="<?php prefill('dateEnd') ?>">
             </div>
             <div id="person-amount" class="search-input" style="display: inline-block">
                 <label id="person-amount-label" for="person-amount-input-field" style="display: block; text-align: left">Personen</label>
-                <input id="person-amount-input-field" placeholder="2" class="input-field" name="persons" type="number" value="<?php pold('persons') ?>">
+                <input id="person-amount-input-field" placeholder="2" class="input-field" name="persons" type="number" value="<?php prefill('persons') ?>">
             </div>
             <div class="submit">
                 <button class="btn-primary"><span class="optional-search-text">Ferienhaus</span> suchen</button>


### PR DESCRIPTION
Change all occurences of pold to prefill.

Where prefill doesn't work because of deep array structure, use $_SESSION['old_POST'] manually.

Offer creation fields now get prefilled after an exception occured in backend causing a redirected. Prefills:
- base-data
- feature checkboxes
- tags
(images are not possible to prefill. The user has to put them in again)