### PR TITLE
Restrict House deletion

### DIFF
--- a/src/controller/OfferController.php
+++ b/src/controller/OfferController.php
@@ -165,9 +165,15 @@ class OfferController extends BaseController
         $this->isUserAllowedHere($houseId, 'house', '/offer');
         try {
             /** @var House $house */
+            // prevent deleting houses that have dependencies in db (bookings)
+            if ($house->getBookedDates() != "") {
+                throw new Exception("Dependencies in database prevent deletion of house ({$houseId})");
+            }
             $house->deleteHouse();
         } catch (Exception $e) {
-            $_SESSION['message'] = 'Haus konnte nicht gelöscht werden. Gibt es Buchungen ? (->bookingpositions)'; // todo : change message text after deciding if houses can be deleted
+            // disable the house instead of deleting it
+            $house->toggleStatus(1);
+            $_SESSION['message'] = 'Die Ferienwohnung kann nicht gelöscht werden, da sie bereits mindestens einmal gebucht wurde. Sie wurde stattdessen deaktiviert.';
             redirect($_SESSION['previous'], 302);
             die();
         }

--- a/src/models/House.php
+++ b/src/models/House.php
@@ -94,12 +94,29 @@ class House extends BaseModel
         return trim($string, ',');
     }
 
-    public function toggleStatus(): void
+    /**
+     * Toggle the status of a house
+     *
+     * If $newStatus is given this value will be set as status:
+     * - value 1 disables the house
+     * - value 0 enables the house
+     *
+     * @param int|null $newStatus
+     * @return void
+     */
+    public function toggleStatus(int $newStatus = null): void
     {
-//        get old status and invert
-        $newStatus = (int)!$this->getIsDisabled();
+        if ($newStatus === null) {
+            // get old status and invert
+            $newStatus = (int)!$this->getIsDisabled();
+            // or sanitize input
+        } elseif ($newStatus > 1) {
+            $newStatus = 1;
+        } elseif ($newStatus < 0) {
+            $newStatus = 0;
+        }
+        // write to db
         $query = "update houses set is_disabled = {$newStatus}  where id = {$this->getId()}";
-//        write to db
         $this->connection()->query($query);
     }
 

--- a/src/views/offerIndex.view.php
+++ b/src/views/offerIndex.view.php
@@ -34,11 +34,14 @@ if (isset($houses)) {
                             <?php $house->getIsDisabled() == 1 ? print('Aktivieren') : print('Deaktivieren') ?>
                         </button>
                     </form>
-                    <form action="/offer/delete/<?php echo $house->getId(); ?>" method="post">
-                        <button type="submit" class="btn-secondary">
-                            Löschen
-                        </button>
-                    </form>
+                    <?php if ($house->getBookedDates() == "") { ?>
+                        <!-- deleting a house is only possible if no bookings exist for that house -->
+                        <form action="/offer/delete/<?php echo $house->getId(); ?>" method="post">
+                            <button type="submit" class="btn-secondary">
+                                Löschen
+                            </button>
+                        </form>
+                    <?php } ?>
                 </div>
             </div>
             <div class="card-calendars">


### PR DESCRIPTION
A house can only be deleted when no booking exists for that house.
The deletion-button is only rendered if this condition is met.

If a house is getting deleted and still bookings exist, the deletion process gets canceled and the house will be disabled. 

As fallback, if a house can not be deleted, it will be disabled instead.