### PR TITLE
Save search data in session and use it

### DIFF
--- a/src/controller/DashboardController.php
+++ b/src/controller/DashboardController.php
@@ -10,6 +10,12 @@ class DashboardController extends BaseController
 
     public function getindex(mixed $formdata = null): void
     {
+        // reset search-data of session
+        if (isset($_SESSION['search-data'])) {
+            unset($_SESSION['search-data']);
+        }
+        // todo : reset filter data
+
         new ViewController('dashboard');
     }
 }

--- a/src/controller/OfferController.php
+++ b/src/controller/OfferController.php
@@ -347,15 +347,18 @@ class OfferController extends BaseController
      */
     public function getFind($param)
     {
-        //prepare search parameter
+        // prepare search parameter and save them into session if they exist
+            // (data source: 1. dashboard or 2. session or 3. default )
         /** @var string $destination */
-        $destination = $param['destination'] ?? '';
+        $destination = $_SESSION['search-data']['destination'] = $param['destination'] ?? $_SESSION['search-data']['destination'] ?? '';
         /** @var string $dateStart */
-        $dateStart = $param['dateStart'] ?? '';
+        $dateStart = $_SESSION['search-data']['dateStart'] = $param['dateStart'] ?? $_SESSION['search-data']['dateStart'] ?? '';
         /** @var string $dateEnd */
-        $dateEnd = $param['dateEnd'] ?? '';
+        $dateEnd = $_SESSION['search-data']['dateEnd'] = $param['dateEnd'] ?? $_SESSION['search-data']['dateEnd'] ?? '';
         /** @var string $persons */
-        $persons = (int)($param['persons'] ?? 0);
+        $persons = $_SESSION['search-data']['persons'] = (int)($param['persons'] ?? $_SESSION['search-data']['persons'] ?? 0);
+
+        // prepare query
         $query = "
 SELECT *
 FROM houses h
@@ -385,8 +388,9 @@ and
         if ($persons > 0) {
             $query .= "and max_person >= {$persons}";
         }
-
+        // execute query
         $result = $this->connection()->query($query);
+
         $houses = [];
         $houseCount = 0;
         if ($result instanceof \mysqli_result) {
@@ -395,8 +399,8 @@ and
                 $houseCount++;
             }
         }
-        $_SESSION['old_POST'] = $param;
-//        unset old data
+
+        // unset old data
         $param = [];
 
         // prepare displaying all features

--- a/src/views/bookingCreate.view.php
+++ b/src/views/bookingCreate.view.php
@@ -11,7 +11,9 @@ include_once($header);
 
 <img id="title-image" src="/images/<?php print $house->getFrontImage(); ?>" style="" alt="alt">
 
+<button class="btn-secondary" type="button" onclick="openLink('<?php echo "/offer/detail/".$house->getId(); ?>')">Zurück</button> <!-- todo : make me pretty (Marvin) -->
 <h1 class="title"><?php print $house->getName(); ?> buchen</h1>
+
 <form action="/booking/create/" method="post" id="booking-form">
 
     <div class="description-area">
@@ -35,10 +37,10 @@ include_once($header);
         <h3>Buchungszeitraum</h3>
         <label class="label" for="date_start">Von</label>
         <input class="input-field" type="date" id="date_start" name="date_start"
-               value="<?php prefill('date_start') ?>" required>
+               value="<?php echo $_SESSION['search-data']['dateStart'] ?? ''; ?>" required>
         <label class="label" for="date_end">Bis</label>
         <input class="input-field" type="date" id="date_end" name="date_end"
-               value="<?php prefill('date_end') ?>" required>
+               value="<?php echo $_SESSION['search-data']['dateEnd'] ?? ''; ?>" required>
     </div>
     <div class="options-area">
         <h3>Zusatzoptionen</h3>

--- a/src/views/offerDetail.view.php
+++ b/src/views/offerDetail.view.php
@@ -174,7 +174,7 @@ include_once($footer)
     <div class="modal-content card option-card">
         <span class="close-button">&times;</span>
         <div class="option-image">
-            <img src="/" alt="alt">
+            <img src="" alt="alt">
         </div>
         <div class="option-name">
             <h3>Option Name</h3>

--- a/src/views/search.view.php
+++ b/src/views/search.view.php
@@ -18,24 +18,24 @@ include_once($header);
             <div id="destination" class="search-input" style="display: inline-block;text-align: left">
                 <label id="destination-label" style="display: block" for="destination-input-field">Reiseziel</label>
                 <input id="destination-input-field" placeholder="Rügen" class="input-field" name="destination"
-                       type="text" value="<?php prefill('destination') ?>">
+                       type="text" value="<?php echo $_SESSION['search-data']['destination'] ?? ''; ?>">
             </div>
             <div id="from-date" class="search-input" style="display: inline-block">
                 <label id="from-date-label" for="from-date-input-field"
                        style="display: block;text-align: left">Anreise</label>
                 <input id="from-date-input-field" class="input-field" name="dateStart" type="date"
-                       value="<?php prefill('dateStart') ?>">
+                       value="<?php echo $_SESSION['search-data']['dateStart'] ?? ''; ?>">
             </div>
             <div id="to-date" class="search-input" style="display: inline-block">
                 <label id="to-date-label" for="to-date-input-field" style="display: block;text-align: left">Abreise</label>
                 <input id="to-date-input-field" class="input-field" name="dateEnd" type="date"
-                       value="<?php prefill('dateEnd') ?>">
+                       value="<?php echo $_SESSION['search-data']['dateEnd'] ?? ''; ?>">
             </div>
             <div id="person-amount" class="search-input" style="display: inline-block">
                 <label id="person-amount-label" for="person-amount-input-field"
                        style="display: block; text-align: left">Personen</label>
                 <input id="person-amount-input-field" placeholder="2" class="input-field" name="persons" type="number"
-                       value="<?php prefill('persons') ?>">
+                       value="<?php echo $_SESSION['search-data']['persons'] ?? '0'; ?>">
             </div>
             <div class="submit">
                 <button class="btn-primary"><span class="optional-search-text">Ferienhaus</span> suchen</button>


### PR DESCRIPTION
Save search data in session and prefill it in /offer/find if no other data is provided

Reset this data if visiting dashboard

Add "zurück"-button from booking creation to detail-page

Fix bug, that always loaded the dashboard when building /offer/detail page. (Caused by image source set to "/" in modal for displaying an option)