### PR TITLE
Fix redirect target if checkout is empty

### DIFF
--- a/src/controller/CheckoutController.php
+++ b/src/controller/CheckoutController.php
@@ -39,7 +39,6 @@ class CheckoutController extends BaseController
                 if ($param["bookingpositions"] == false) {
                     new ViewController('cart');
                     die();
-                } else {
                 }
 
                 // get all houses related to all bookingpositions

--- a/src/views/checkout.view.php
+++ b/src/views/checkout.view.php
@@ -10,11 +10,9 @@ include_once($header);
 
 // auto redirect if there is nothing in the cart
 if (!(isset($booking) && !empty($bpos) && !empty($houses))) {
-    $_SESSION['redirect_back'] = $_SERVER['REQUEST_URI'];
-    redirect('/dashboard', 302);
+    redirect('/cart', 302);
     die();
 }
-
 ?>
     <link rel="stylesheet" href="/styles/checkout.css"/>
     <div class="headline">


### PR DESCRIPTION
If checkout is empty, redirect now leads to the cart which already provides a message like "cart is empty".